### PR TITLE
Improved caching of exceptions

### DIFF
--- a/src/DR.Sleipner.EnyimMemcachedProvider/EnyimMemcachedProvider.cs
+++ b/src/DR.Sleipner.EnyimMemcachedProvider/EnyimMemcachedProvider.cs
@@ -40,6 +40,10 @@ namespace DR.Sleipner.EnyimMemcachedProvider
 
                 if (cachedObject.IsException && fresh)
                 {
+                    if (cachedObject.Exception != null)
+                    {
+                        return new CachedObject<TObject>(CachedObjectState.Exception, cachedObject.Exception);
+                    }
                     return new CachedObject<TObject>(CachedObjectState.Exception, new Exception("Exception stored in memcached"));
                 }
 
@@ -71,6 +75,7 @@ namespace DR.Sleipner.EnyimMemcachedProvider
             {
                 Created = DateTime.Now,
                 IsException = true,
+                Exception = exception,
             };
 
             _client.Store(StoreMode.Set, key, cachedObject);

--- a/src/DR.Sleipner.EnyimMemcachedProvider/Model/MemcachedObject.cs
+++ b/src/DR.Sleipner.EnyimMemcachedProvider/Model/MemcachedObject.cs
@@ -10,5 +10,6 @@ namespace DR.Sleipner.EnyimMemcachedProvider.Model
         public TObject Object;
         public bool IsException;
         public DateTime Created;
+        public Exception Exception;
     }
 }

--- a/src/DR.Sleipner/CacheProxy/CacheProxyBase.cs
+++ b/src/DR.Sleipner/CacheProxy/CacheProxyBase.cs
@@ -19,6 +19,7 @@ namespace DR.Sleipner.CacheProxy
             RealInstance = real;
             _cacheProvider = cacheProvider;
 
+            // see: http://stackoverflow.com/questions/57383/in-c-how-can-i-rethrow-innerexception-without-losing-stack-trace/1663549#1663549
             MethodInfo preserveStackTrace = typeof(Exception).GetMethod("InternalPreserveStackTrace", BindingFlags.Instance | BindingFlags.NonPublic);
             _preserveInternalException = (Action<Exception>)Delegate.CreateDelegate(typeof(Action<Exception>), preserveStackTrace);
         }


### PR DESCRIPTION
All .NET exceptions should be serializeable (according to this: http://stackoverflow.com/questions/342528/are-all-net-exceptions-serializable) so we should be able to  cache exceptions. I don't think we can always expect to get an exact copy back, as stuff like the ResponseStream on a WebException clearly can't be serialized, but as long as the type is right I think we should be okay.

Better that current affairs anyways :-)

This patch changes two things:

1) First layer of TargetInvocationExceptions are always stripped. These originate from Sleipner itself and they should be stripped for the proxy to be truly transparent.

2) Try to Cache exceptions and rethrow them, and only using the current plain "Exception stored in memcached" Exception as a fallback.
